### PR TITLE
issues 4: Propagate exit code

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,3 +38,7 @@ if (process.platform === "win32") {
 } else {
     platformSpecific = spawn("npm", options, { shell: true, stdio: "inherit" });
 }
+
+platformSpecific.on("exit", (code) => {
+    process.exit(code);
+});


### PR DESCRIPTION
When the platform-specific script fails, it usually ends with a non-zero exit code. run-script-os hides those failures. In order to be really isomorphic, exit codes should be propagated when the script exits. Code is taken from comment of UselessPickles.