### PR TITLE
Add support for npm test shortcuts/aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,10 @@ let options = npmArgs.original;
 if (!(options[0] === "run" || options[0] === "run-script")) {
   options.unshift("run");
 }
+// Expand the "test" shortcut of "t"
+if (options[1] === "t"){
+  options[1] = "test"
+}
 
 // Check for yarn without install command; fixes #13
 if (process.env.npm_config_user_agent.includes('yarn') && !options[1]) options[1] = 'install';

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ if (!(options[0] === "run" || options[0] === "run-script")) {
   options.unshift("run");
 }
 // Expand the "test" shortcut of "t"|"tst"
-if (["t", "tst"].indexOf(options[1]) > 1){
+if (["t", "tst"].indexOf(options[1]) > -1){
   options[1] = "test"
 }
 

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ if (!(options[0] === "run" || options[0] === "run-script")) {
   options.unshift("run");
 }
 // Expand the "test" shortcut of "t"
-if (options[1] === "t"){
+if (["t", "tst"].indexOf(options[1]) > 1){
   options[1] = "test"
 }
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ let options = npmArgs.original;
 if (!(options[0] === "run" || options[0] === "run-script")) {
   options.unshift("run");
 }
-// Expand the "test" shortcut of "t"
+// Expand the "test" shortcut of "t"|"tst"
 if (["t", "tst"].indexOf(options[1]) > 1){
   options[1] = "test"
 }


### PR DESCRIPTION
If users run `npm tst` instead of `npm test` or `npm t`, it is currently trying to run `t:${platform}` instead of the expanded `test:${platform}`

See https://docs.npmjs.com/cli/test