### PR TITLE
Allow chaining yarn commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ if (process.env.RUN_OS_WINBASH_IS_LINUX) {
 }
 
 const scripts = require(path.join(process.cwd(), "package.json")).scripts;
+const currentScript = process.env.npm_lifecycle_event;
 
 let npmArgs = JSON.parse(process.env["npm_config_argv"]);
 let options = npmArgs.original;
@@ -68,7 +69,11 @@ if (!foundMatch && (`${options[1]}:default` in scripts)) {
   foundMatch = true;
 }
 
-options[1] = osCommand;
+if (!foundMatch && options[1] === currentScript) {
+  // Avoid to run loop on script when not found
+  process.exit(0);
+}
+options[1] = foundMatch ? osCommand : currentScript;
 
 let platformSpecific;
 if (platform === "win32") {


### PR DESCRIPTION
Fixes #26 and #16

This fix checks if we found the os specific command, if not we use the `process.env.npm_lifecycle_event`.

Will fix on a `*nix` OS :
```sh
{
    "script1": "yarn script2 && echo OK2",
    "script2": "npx run-script-os",
    "script2:nix": "echo OK1"
  }
# OK1
# OK2
```

Also fixing :
```sh
{
    "script1": "yarn script2 && echo OK2",
    "script2": "npx run-script-os",
    "script2:win": "echo OK1"
  }
# OK2
```

It also avoid the use of `cd .` in `xxx:default` for every command.