### PR TITLE
Prefer using yarn command if run-script-os is invoked by yarn

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,8 @@ if (!(options[0] === "run" || options[0] === "run-script")) {
 options[1] = expandShorthand(options[1]);
 
 // Check for yarn without install command; fixes #13
-if (process.env.npm_config_user_agent.includes('yarn') && !options[1]) options[1] = 'install';
+const isYarn = process.env.npm_config_user_agent.includes('yarn');
+if (isYarn && !options[1]) options[1] = 'install';
 
 let osCommand = `${options[1]}:${platform}`;
 let foundMatch = true;
@@ -65,7 +66,7 @@ let event = process.env["npm_lifecycle_event"];
  * Yarn support
  * Check for yarn without install command; fixes #13
  */
-if (process.env.npm_config_user_agent.includes('yarn') && !argument) {
+if (isYarn && !argument) {
   argument = 'install';
 }
 
@@ -110,16 +111,18 @@ if (args.includes('--no-arguments')) {
  *
  * Open either the cmd file or the cmd command, if we're in windows
  */
-let platformSpecific;
+let packageManagerCommand;
+
+packageManagerCommand = isYarn ? "yarn" : "npm";
 if (platform === "win32") {
-  platformSpecific = spawn("npm.cmd", options, { shell: true, stdio: "inherit"});
-} else {
-  platformSpecific = spawn("npm", options, { shell: true, stdio: "inherit" });
+  packageManagerCommand = packageManagerCommand + ".cmd";
 }
+
+const childProcess = spawn(packageManagerCommand, options, { shell: true, stdio: "inherit"});
 
 /**
  * Finish the execution
  */
-platformSpecific.on("exit", (code) => {
+childProcess.on("exit", (code) => {
   process.exit(code);
 });


### PR DESCRIPTION
This pull request changes to use `yarn run` instead of `npm run` if the `run-script-os` command is launched via yarn.

It fixes the following `npm` warning message.

```
npm WARN lifecycle The node binary used for scripts is /var/folders/0g/********************/T/yarn--1599640901601-0.7812210040466194/node but npm is using /Users/*******/.nvm/versions/node/v14.7.0/bin/node itself. Use the `--scripts-prepend-node-path` option to include the path for the node binary npm was executed with.
```
