### PR TITLE
Fix arguments handling passed to run-script-os

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,13 +96,25 @@ if (!(options[0] === "run" || options[0] === "run-script")) {
  */
 options[1] = osCommand;
 
+
+const supportedArgs = ['--no-arguments'];
+let args = process.argv.slice(2).map((a) => a.toLowerCase());;
+let argsCount = 0;
+for (let i = 0; i < args.length; i += 1) {
+  if (supportedArgs.includes(args[i])) {
+    argsCount = i;
+  }
+}
+args = args.slice(0, argsCount);
+
 /**
+ * Append arguments passed to the run-script-os
  * Check if we should be passing the original arguments to the new script
  * Fix for #23
  */
-const args = process.argv.slice(2).map((a) => a.toLowerCase());
-if (args.includes('--no-arguments')) {
-  options = options.slice(0,2);
+options = options.slice(0,2);
+if (!args.includes('--no-arguments')) {
+  options = options.concat(process.argv.slice(2 + argsCount));
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "posttest": "echo '6. Posttest (Generic) is finally called after all of the OS specific commands are called'",
     "test-error": "run-script-os",
     "test-error:linux": "echo 'Run $? afterwards to confirm the error code is propagating appropriately.' && exit 11",
-    "test-error:win32": "echo 'Run $LASTEXITCODE (PowerShell) or %errorlevel% (CMD) afterwards to confirm the error code is propagating appropriately.' && exit 22"
+    "test-error:win32": "echo 'Run $LASTEXITCODE (PowerShell) or %errorlevel% (CMD) afterwards to confirm the error code is propagating appropriately.' && exit 22",
+    "test-args": "run-script-os 'Hello,' 'run-script-os.'",
+    "test-args:default": "echo"
   },
   "author": "Charlie Guse (https://github.com/charlesguse/run-script-os)",
   "license": "MIT",


### PR DESCRIPTION
This pull request fixes arguments handling passed to the `run-script-os` command.


### Example scenario

👇  `package.json`
```json
{
  "scripts": {
    "msg": "run-script-os",
    "msg:default": "echo"
  }
}
```

👇  **current behavior**
```bash
npm run msg "Hello," "world!"
> echo
```

👇  **expected behavior**
```bash
npm run msg "Hello," "world!"
> echo "Hello," "world!"
```
