### PR TITLE
Updated the tests to include npm@7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         node-version:
-          - 12
+          #- 12
           - 14
     steps:
       - uses: actions/checkout@v2
@@ -23,7 +23,21 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Starting NPM version
+        run: npm --version
       - name: Installing node modules for the tests (working-directory is ./tests)
         run: npm install
       - name: Running tests
+        run: npm test
+      - name: Update NPM to the latest version
+        run: npm install -g npm@latest
+      - name: Latest NPM version
+        run: npm --version
+      - name: Running tests at latest NPM version
+        run: npm test
+      - name: Update NPM to the latest version
+        run: npm install -g npm@next
+      - name: Latest NPM version
+        run: npm --version
+      - name: Running tests at latest NPM version
         run: npm test

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -11,6 +11,9 @@ jobs:
         working-directory: ./tests
     strategy:
       matrix:
+        include:
+          - npm-version: latest
+          - npm-version: next-7
         os:
           - macos-latest
           - ubuntu-latest
@@ -24,23 +27,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Starting NPM version
+      - name: Update NPM to ${{ matrix.npm-version }}
+        env:
+          NPM_VERSION: ${{ matrix.npm-version }}
+        run: npm install -g npm@$NPM_VERSION
+      - name: npm version
         run: npm --version
       - name: Installing node modules for the tests (working-directory is ./tests)
         run: npm ci
       - name: Running tests
-        run: npm test
-      - name: Update NPM to the latest version
-        run: npm install -g npm@latest
-      - name: Latest NPM version
-        run: npm --version
-      - name: Running tests at latest NPM version
-        run: npm test
-      - name: Update NPM to the latest version
-        run: npm install -g npm@next
-      - name: Latest NPM version
-        run: npm --version
-      - name: Running tests at latest NPM version
         run: npm test
   deploy:
     name: Publish to NPM

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -6,6 +6,7 @@ jobs:
   test:
     name: Test on different OSes and Node versions
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     # run-script-os doesn't have dependencies.
     # The tests have run-script-os as a dependency
     # Because of that, the tests folder is the working
@@ -24,14 +25,14 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-        node-version:
-          - 14
-        npm-version:
-          - latest
+        node-version: [14]
+        npm-version: [latest]
+        experimental: [false]
         include:
           - os: ubuntu-latest
             node-version: 14
             npm-version: next-7
+            experimental: true
     steps:
       - uses: actions/checkout@v2
       - name: Testing run-script-os with nodejs@${{ matrix.node-version }}/npm@${{ matrix.npm-version }} on ${{ matrix.os }} from a tests project similar to how run-script-os is used by others.

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -6,24 +6,33 @@ jobs:
   test:
     name: Test on different OSes and Node versions
     runs-on: ${{ matrix.os }}
+    # run-script-os doesn't have dependencies.
+    # The tests have run-script-os as a dependency
+    # Because of that, the tests folder is the working
+    # directory for tests
     defaults:
       run:
         working-directory: ./tests
     strategy:
+      # Testing npm@latest using nodejs@14 on the different operating systems.
+      # Flexible to add more test environments across the different operating systems
+      # Include an aditional test using npm@next-7
       matrix:
-        npm-version:
-          - latest
-          - next-7
         os:
           - macos-latest
           - ubuntu-latest
           - windows-latest
         node-version:
-          #- 12
           - 14
+        npm-version:
+          - latest
+        include:
+          - os: ubuntu-latest
+            node-version: 14
+            npm-version: next-7
     steps:
       - uses: actions/checkout@v2
-      - name: Testing run-script-os with Node.js ${{ matrix.node-version }} on ${{ matrix.os }} from a tests project similar to how run-script-os is used by others.
+      - name: Testing run-script-os with nodejs@${{ matrix.node-version }}/npm@${{ matrix.npm-version }} on ${{ matrix.os }} from a tests project similar to how run-script-os is used by others.
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
@@ -33,9 +42,9 @@ jobs:
         run: npm install -g npm@$NPM_VERSION
       - name: npm version
         run: npm --version
-      - name: Installing node modules for the tests (working-directory is ./tests)
+      - name: Installing run-script-os and other testing dependencies for the tests (working-directory is ./tests)
         run: npm ci
-      - name: Running tests
+      - name: Running tests (working-directory is ./tests)
         run: npm test
   deploy:
     name: Publish to NPM

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Installing run-script-os and other testing dependencies for the tests (working-directory is ./tests)
         run: npm ci
       - name: Running tests (working-directory is ./tests)
-        run: npm test
+        run: npm run test
   deploy:
     name: Publish to NPM
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -11,9 +11,9 @@ jobs:
         working-directory: ./tests
     strategy:
       matrix:
-        include:
-          - npm-version: latest
-          - npm-version: next-7
+        npm-version:
+          - latest
+          - next-7
         os:
           - macos-latest
           - ubuntu-latest

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   test:
-    name: Test on different OSes and Node versions
+    name: Test ${{ matrix.os }}:${{ matrix.node-version }}/npm@${{ matrix.npm-version }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     # run-script-os doesn't have dependencies.

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Installing run-script-os and other testing dependencies for the tests (working-directory is ./tests)
         run: npm ci
       - name: Running tests (working-directory is ./tests)
-        run: npm run test
+        run: npm test
   deploy:
     name: Publish to NPM
     if: github.ref == 'refs/heads/master'

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -17,6 +17,8 @@ jobs:
       # Testing npm@latest using nodejs@14 on the different operating systems.
       # Flexible to add more test environments across the different operating systems
       # Include an aditional test using npm@next-7
+      # Run all of the test environments to see all of the environments that have issues.
+      fail-fast: false
       matrix:
         os:
           - macos-latest

--- a/functions.js
+++ b/functions.js
@@ -48,7 +48,7 @@
       /**
        * macOS specific scripts (e.g. brew)
        */
-      result = (`${script}:darwin` in scripts) ? `${script}:darwin` : false;
+      result = (`${script}:macos` in scripts) ? `${script}:macos` : false;
 
       /**
        * nix compatible scripts (cp, rm...)

--- a/index.js
+++ b/index.js
@@ -8,12 +8,16 @@ const path = require("path");
 const matchScript = require ('./functions.js').matchScript;
 const expandShorthand = require('./functions.js').expandShorthand;
 
+const INCORRECT_USAGE_CODE = 1000
+const MISSING_COMMAND_CODE = 1001
+
+
 /**
  * This package can only be executed from within the npm script execution context
  */
 if (!process.env["npm_config_argv"]) {
   console.log("This is meant to be run from within npm script. See https://github.com/charlesguse/run-script-os");
-  return;
+  process.exit(INCORRECT_USAGE_CODE);
 }
 
 /**
@@ -82,7 +86,7 @@ osCommand = matchScript(event || argument, platform, scripts);
  */
 if (!osCommand) {
   console.log(`run-script-os was unable to execute the script '${event || argument}'`);
-  process.exit(0);
+  process.exit(MISSING_COMMAND_CODE);
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -8,8 +8,8 @@ const path = require("path");
 const matchScript = require ('./functions.js').matchScript;
 const expandShorthand = require('./functions.js').expandShorthand;
 
-const INCORRECT_USAGE_CODE = 1000
-const MISSING_COMMAND_CODE = 1001
+const INCORRECT_USAGE_CODE = 255
+const MISSING_COMMAND_CODE = 254
 
 
 /**

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,7 +5,7 @@
         "test": "run-script-os",
         "test:windows": "@powershell -NoProfile -Command \"Invoke-Pester -Configuration (Get-Content ./windows.configuration.json | ConvertFrom-Json) | Select-Object -ExpandProperty FailedCount | Should -BeNull\"",
         "test:linux": "./linux.test.sh",
-        "test:macos": "./macos.test.sh",
+        "test:darwin": "./macos.test.sh",
 
         "get-pester-defaults": "@powershell -NoProfile -Command \"Import-Module Pester; [PesterConfiguration]::Default\"",
 


### PR DESCRIPTION
By default, the tests will check the `latest` version of npm (currently 6) and node 14 on the different operating systems.

While doing this, I found that I must have broken the `macos` tag again. No more though! If run-script-os exits early, it now returns an error code. In doing so, the pipeline will recognize a regression of the `macos` tag if it happens again in the future.